### PR TITLE
Fix 403 forbidden pixel issue

### DIFF
--- a/assets/widget.js
+++ b/assets/widget.js
@@ -15,8 +15,8 @@ function modal_actions(){
 	var parser = new DOMParser();
 	var doc = parser.parseFromString(html, "text/html");
 	$(doc).find('.wp-caption').remove();
-	var captionless = $(doc).find('body').html()
-	$shareable.text(captionless);
+	var captionless = $(doc).find('body').html();
+	$shareable.html(captionless);
 
 	// Responsive modal
 	var $modal = $('#republication-tracker-tool-modal');

--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -95,8 +95,8 @@ class Republication_Tracker_Tool_Settings {
 			$analytics_id = get_option( 'republication_tracker_tool_analytics_id' );
 			$pixel = sprintf(
 				// %1$s is the javascript source, %2$s is the post ID, %3$s is the plugins URL
-				'<img id="republication-tracker-tool-source" src="%1$s?post=%2$s&ga=%3$s">',
-				plugins_url( 'includes/pixel.php', dirname( __FILE__ ) ),
+				'<img id="republication-tracker-tool-source" src="%1$s/?republication-pixel=true&post=%2$s&ga=%3$s">',
+				esc_attr( get_site_url( ) ),
 				'YOUR-POST-ID',
 				esc_attr( $analytics_id )
 			);

--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -5,24 +5,29 @@ function wprtt_get_referring_page_title( $url ){
 
 	$response = wp_remote_get( $url );
 
-	// find the title element inside of the response body
-	$response = preg_match( "/<title.[^>]*>(.*)<\/title>/siU", $response['body'], $title_matches );
+	// if there was no issue grabbing the url, continue
+	if( !is_wp_error( $response ) ){
 
-	// if a title element was found, let's get the text from it
-	if( $title_matches ){
+		// find the title element inside of the response body
+		$response = preg_match( "/<title.[^>]*>(.*)<\/title>/siU", $response['body'], $title_matches );
 
-		// clean up title: remove EOL's and excessive whitespace.
-		$title = preg_replace( '/\s+/', ' ', $title_matches[1] );
-		$title = trim( $title );
-		$title = rawurlencode( $title );
+		// if a title element was found, let's get the text from it
+		if( $title_matches ){
 
-		// return our found title
-		return $title;
-	
-	// if there were no title matches found, don't continue
-	} else {
+			// clean up title: remove EOL's and excessive whitespace.
+			$title = preg_replace( '/\s+/', ' ', $title_matches[1] );
+			$title = trim( $title );
+			$title = rawurlencode( $title );
 
-		return;
+			// return our found title
+			return $title;
+		
+		// if there were no title matches found, don't continue
+		} else {
+
+			return;
+
+		}
 
 	}
 

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -89,8 +89,8 @@ $attribution_statement = sprintf(
  */
 $pixel = sprintf(
 	// %1$s is the javascript source, %2$s is the post ID, %3$s is the plugins URL
-	'<img id="republication-tracker-tool-source" src="%1$s?republication-pixel=true&post=%2$s&ga=%3$s">',
-	plugins_url( '/', dirname( __FILE__ ) ),
+	'<img id="republication-tracker-tool-source" src="%1$s/?republication-pixel=true&post=%2$s&ga=%3$s">',
+	esc_attr( get_site_url( ) ),
 	esc_attr( $post->ID ),
 	esc_attr( $analytics_id )
 );

--- a/republication-tracker-tool.php
+++ b/republication-tracker-tool.php
@@ -128,11 +128,15 @@ final class Republication_Tracker_Tool {
 		add_filter( 'query_vars', array( $this, 'enable_pixel_query_vars' ) );
 
 		// fire our pixel is the correct param is set
-		if( isset( $_GET['republication-pixel'] ) && isset( $_GET['post'] ) && isset( $_GET['ga'] ) ){
-
-			return include_once( plugin_dir_path( __FILE__ ).'includes/pixel.php' );
-
-		}
+		add_filter( 'template_include', function( $template ) {
+			// if the params are set, use our pixel functions
+			if( isset( $_GET['republication-pixel'] ) && isset( $_GET['post'] ) && isset( $_GET['ga'] ) ){
+				return include_once( plugin_dir_path( __FILE__ ).'includes/pixel.php' );
+			// else, continue with whatever template was being loaded
+			} else {
+				return $template;
+			}
+		}, 99 );
 
 	}
 


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Changes the way we fire the pixel. Instead of firing it at `/wp-content/plugins/republication-tracker-tool/?query_params`, we'll now fire it at `site.com/*?query_params`. This _should be_ backwards compatible so sites experiencing the 403 issue in their republished posts should have the issue resolved once updated.

- Updates the `modal_actions` function to use `.html()` instead of `.text()` when copying the content into the sharable modal so that the pixel `&`'s don't get encoded into `&amp;` and cause issues if pasted into a CMS that doesn't automatically decode html entities.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #50 and #48.

## Testing/Questions

Features that this PR affects:

- The pixel redirect when the pixel url is requested.

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] Does this work ok?
- [x] Does the copyable content still look ok?
- [x] Is it still tracking as expected?

Steps to test this PR:

1. Create post to be republished
2. View post, open modal, copy sharable content
3. Ensure shareable content doesn't have encoded `&`'s in the pixel url
4. Paste copyable content into new post
5. Verify pixel url returns an image in new post
6. Verify the view from the new post is recorded in GA