### PR TITLE
Only remove `form` elements from shareable content

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,5 @@
 2. [Configuring plugin settings](configuring-plugin-settings.md)
 3. [Adding Republish button to posts](adding-republish-button-to-posts.md)
 4. [Styling the Republish button](styling-the-republish-button.md)
-5. [Tracking republished posts](tracking-republished-posts.md)
+5. [Removing Elements from Shareable Content](removing-elements-from-shareable-content.md)
+6. [Tracking republished posts](tracking-republished-posts.md)

--- a/docs/removing-elements-from-shareable-content.md
+++ b/docs/removing-elements-from-shareable-content.md
@@ -1,0 +1,22 @@
+# Removing HTML Elements from the Shareable Content
+
+If you'd like to remove specific HTML elements from the shareable content widget, you can use the `republication_tracker_tool_allowed_tags_excerpt` filter. The array returned through this filter is used to run the post content through the <a href="https://codex.wordpress.org/Function_Reference/wp_kses" target="_blank">`wp_kses`</a> function.
+
+Here's an example of how to remove `video` and `button` elements from the shareable content:
+
+```
+/**
+* Remove video and button elements from the shareable content
+*
+* @return Array $allowed_tags_excerpt The array of tags to allow in the shareable content
+**/
+function remove_elements_from_shareable_content( $allowed_tags_excerpt, $post ){
+
+    unset( $allowed_tags_excerpt['video'] );
+    unset( $allowed_tags_excerpt['button'] );
+
+    return $allowed_tags_excerpt;
+
+}
+add_filter( 'republication_tracker_tool_allowed_tags_excerpt', 'remove_elements_from_shareable_content', 10, 2 );
+```

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -20,15 +20,7 @@
  */
 global $allowedposttags;
 $allowed_tags_excerpt = $allowedposttags;
-unset( $allowed_tags_excerpt['audio'] );
-unset( $allowed_tags_excerpt['figure'] );
-unset( $allowed_tags_excerpt['figcaption'] );
-unset( $allowed_tags_excerpt['img'] );
 unset( $allowed_tags_excerpt['form'] );
-unset( $allowed_tags_excerpt['button'] );
-unset( $allowed_tags_excerpt['track'] );
-unset( $allowed_tags_excerpt['video'] );
-
 
 /**
  * The article WP_Post object

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -7,6 +7,13 @@
  */
 
 /**
+ * The article WP_Post object
+ *
+ * @var WP_Post $post the post object
+ */
+global $post;
+
+/**
  * What tags do we want to keep in the embed?
  * Not things from our server.
  *
@@ -31,14 +38,7 @@ unset( $allowed_tags_excerpt['form'] );
  * @link https://developer.wordpress.org/reference/functions/wp_kses_allowed_html/
  * @param Array $allowed_tags_excerpt an associative array of element tags that are allowed
  */
-$allowed_tags_excerpt = apply_filters( 'republication_tracker_tool_allowed_tags_excerpt', $allowed_tags_excerpt );
-
-/**
- * The article WP_Post object
- *
- * @var WP_Post $post the post object
- */
-global $post;
+$allowed_tags_excerpt = apply_filters( 'republication_tracker_tool_allowed_tags_excerpt', $allowed_tags_excerpt, $post );
 
 /**
  * The content of the aforementioned post

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -23,6 +23,17 @@ $allowed_tags_excerpt = $allowedposttags;
 unset( $allowed_tags_excerpt['form'] );
 
 /**
+ * Allow sites to configure which tags are allowed to be output in the republication content
+ * 
+ * Default value is the standard global $allowedposttags, except form elements.
+ *
+ * @link https://github.com/INN/republication-tracker-tool/issues/49
+ * @link https://developer.wordpress.org/reference/functions/wp_kses_allowed_html/
+ * @param Array $allowed_tags_excerpt an associative array of element tags that are allowed
+ */
+$allowed_tags_excerpt = apply_filters( 'republication_tracker_tool_allowed_tags_excerpt', $allowed_tags_excerpt );
+
+/**
  * The article WP_Post object
  *
  * @var WP_Post $post the post object
@@ -41,10 +52,6 @@ $content = strip_shortcodes( $content );
 
 // Remove comments from the content. (Lookin' at you, Gutenberg.)
 $content = preg_replace( '/<!--(.|\s)*?-->/i', ' ', $content );
-
-// Remove captions and figures from the content
-$content = preg_replace( '/<figure[^>]?\>(.|\s)*?<\/figure>/i', ' ', $content );
-$content = preg_replace( '/<figcaption[^>]?\>(.|\s)*?<\/figcaption>/i', ' ', $content );
 
 // And finally, remove some tags.
 $content = wp_kses( $content, $allowed_tags_excerpt );


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Removes the unsetting of specific elements from the `allowed_tags_excerpt` array so elements like images, videos, etc. aren't removed from the shareable content box.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #49

## Testing/Questions

Features that this PR affects:

- Shareable content

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Should we add any other tags to be excluded?

Steps to test this PR:

1. Open Shareable Content box for posts with images, videos, and buttons.