### PR TITLE
Toggle republication on/off for posts

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,5 @@
 2. [Configuring plugin settings](configuring-plugin-settings.md)
 3. [Adding Republish button to posts](adding-republish-button-to-posts.md)
 4. [Styling the Republish button](styling-the-republish-button.md)
-5. [Tracking republished posts](tracking-republished-posts.md)
+5. [Programatically removing the Republish button from certain categories](removing-republish-button-from-categories.md)
+6. [Tracking republished posts](tracking-republished-posts.md)

--- a/docs/removing-republish-button-from-categories.md
+++ b/docs/removing-republish-button-from-categories.md
@@ -7,6 +7,12 @@ The `hide_republication_widget` filter allows you to target specific posts/categ
 Here's an example of how to hide the Republish button on all posts in the category with an ID of 14.
 
 ```
+/**
+* Hide the Republication sharing widget on posts that are
+* included in the category with the ID of 14.
+*
+* @return bool Whether or not the sharing widget should be hidden
+*/
 function remove_republish_button_from_category(){
 
     // grab our current post object
@@ -19,6 +25,8 @@ function remove_republish_button_from_category(){
 		return true;
 
 	}
+
+    return false;
 
 }
 add_filter( 'hide_republication_widget', 'remove_republish_button_from_category', 10 );

--- a/docs/removing-republish-button-from-categories.md
+++ b/docs/removing-republish-button-from-categories.md
@@ -1,0 +1,25 @@
+# Removing the Republish Button From Specific Categories
+
+If you'd like to remove the Republish button from specific categories, the plugin includes a filter that will help you do this programatically. 
+
+The `hide_republication_widget` filter allows you to target specific posts/categories/tags/whatever you want to hide. All you have to do is check if the current post exists in the specific category, and tell the filter to return `true` if you'd like the button to be hidden.
+
+Here's an example of how to hide the Republish button on all posts in the category with an ID of 14.
+
+```
+function remove_republish_button_from_category(){
+
+    // grab our current post object
+	global $post;
+
+    // if the current post is in this category, return true
+	if( in_category( 14, $post->ID ) ){
+		
+        // returning true will cause the filter to hide the button
+		return true;
+
+	}
+
+}
+add_filter( 'hide_republication_widget', 'remove_republish_button_from_category', 10 );
+```

--- a/docs/removing-republish-button-from-categories.md
+++ b/docs/removing-republish-button-from-categories.md
@@ -13,21 +13,22 @@ Here's an example of how to hide the Republish button on all posts in the catego
 *
 * @return bool Whether or not the sharing widget should be hidden
 */
-function remove_republish_button_from_category(){
+function remove_republish_button_from_category( $hide_republication_widget, $post ){
 
-    // grab our current post object
-	global $post;
+    if( true !== $hide_republication_widget ){
 
-    // if the current post is in this category, return true
-	if( in_category( 14, $post->ID ) ){
-		
-        // returning true will cause the filter to hide the button
-		return true;
+        // if the current post is in this category, return true
+        if( in_category( 14, $post->ID ) ){
+            
+            // returning true will cause the filter to hide the button
+            $hide_republication_widget = true;
 
-	}
+        }
+    
+    }
 
-    return false;
+    return $hide_republication_widget;
 
 }
-add_filter( 'hide_republication_widget', 'remove_republish_button_from_category', 10 );
+add_filter( 'hide_republication_widget', 'remove_republish_button_from_category', 10, 2 );
 ```

--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -159,7 +159,7 @@ class Republication_Tracker_Tool_Article_Settings {
 		$hide_republication_widget = apply_filters( 'hide_republication_widget', $hide_republication_widget );
 
 		if( true == $hide_republication_widget ){
-			echo '<p>The Republication sharing widget on this post is programatically disabled through the hide_republication_widget filter.</p>';
+			echo '<p>The Republication sharing widget on this post is programatically disabled through the <code>hide_republication_widget</code> filter. <a href="https://github.com/INN/republication-tracker-tool/blob/master/docs/removing-republish-button-from-categories.md" target="_blank">Read more about this filter</a>.</p>';
 		} else {
 
 			echo '<label>';

--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -68,7 +68,10 @@ class Republication_Tracker_Tool_Article_Settings {
 			array( $this, 'render_hide_widget_metabox' ),
 			array( 'post', 'page' ),
 			'side',
-			'default'
+			'default',
+			array(
+				'__block_editor_compatible_meta_box' => true,
+			)
 		);
 
 	}
@@ -153,10 +156,18 @@ class Republication_Tracker_Tool_Article_Settings {
 
 		}
 
-		echo '<label>';
-			echo '<input type="checkbox" name="republication-tracker-tool-hide-widget" id="republication-tracker-tool-hide-widget" '.$checked.'>';
-			echo __('Hide the Republication sharing widget on this post?', 'republication-tracker-tool');
-		echo '</label>';
+		$hide_republication_widget = apply_filters( 'hide_republication_widget', $hide_republication_widget );
+
+		if( true == $hide_republication_widget ){
+			echo '<p>The Republication sharing widget on this post is programatically disabled through the hide_republication_widget filter.</p>';
+		} else {
+
+			echo '<label>';
+				echo '<input type="checkbox" name="republication-tracker-tool-hide-widget" id="republication-tracker-tool-hide-widget" '.$checked.'>';
+				echo __('Hide the Republication sharing widget on this post?', 'republication-tracker-tool');
+			echo '</label>';
+
+		}
 
 	} 
 

--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -156,7 +156,7 @@ class Republication_Tracker_Tool_Article_Settings {
 
 		}
 
-		$hide_republication_widget = apply_filters( 'hide_republication_widget', $hide_republication_widget );
+		$hide_republication_widget = apply_filters( 'hide_republication_widget', $hide_republication_widget, $post );
 
 		if( true == $hide_republication_widget ){
 			echo '<p>The Republication sharing widget on this post is programatically disabled through the <code>hide_republication_widget</code> filter. <a href="https://github.com/INN/republication-tracker-tool/blob/master/docs/removing-republish-button-from-categories.md" target="_blank">Read more about this filter</a>.</p>';

--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -157,7 +157,6 @@ class Republication_Tracker_Tool_Article_Settings {
 			echo '<input type="checkbox" name="republication-tracker-tool-hide-widget" id="republication-tracker-tool-hide-widget" '.$checked.'>';
 			echo __('Hide the Republication sharing widget on this post?', 'republication-tracker-tool');
 		echo '</label>';
-		
 
 	} 
 

--- a/includes/class-article-settings.php
+++ b/includes/class-article-settings.php
@@ -42,6 +42,7 @@ class Republication_Tracker_Tool_Article_Settings {
 		add_action( 'manage_edit-post_columns', array( $this, 'add_custom_columns' ) );
 		add_action( 'manage_edit-post_sortable_columns', array( $this, 'add_sortable_columns' ) );
 		add_action( 'manage_posts_custom_column' , array( $this, 'custom_column_content' ), 10, 2 );
+		add_action( 'save_post', array( $this, 'save_hide_widget_metabox' ), 10 );
 	}
 
 
@@ -60,6 +61,36 @@ class Republication_Tracker_Tool_Article_Settings {
 			'advanced',
 			'default'
 		);
+
+		add_meta_box(
+			'republication-tracker-tool-hide-widget',
+			esc_html__( 'Hide Republication Widget', 'republication-tracker-tool' ),
+			array( $this, 'render_hide_widget_metabox' ),
+			array( 'post', 'page' ),
+			'side',
+			'default'
+		);
+
+	}
+
+	/**
+	 * Save the value of the hide widget metabox checkbox
+	 * 
+	 * @since 1.0.2
+	 * @param int $post_id The post ID
+	 */
+	public function save_hide_widget_metabox( $post_id ){
+
+		if( isset( $_POST[ 'republication-tracker-tool-hide-widget' ] ) ) {
+
+			update_post_meta( $post_id, 'republication-tracker-tool-hide-widget', true );
+
+		} else {
+
+			update_post_meta( $post_id, 'republication-tracker-tool-hide-widget', false );
+
+		}
+
 	}
 
 	/**
@@ -102,6 +133,33 @@ class Republication_Tracker_Tool_Article_Settings {
 			echo esc_html_e('There are no shares to display.', 'republication-tracker-tool');
 		}
 	}
+
+	/**
+	 * Render a custom metabox to check/uncheck whether or not the sharing widget should be hidden
+	 *
+	 * @since 1.0.2
+	 * @param obj $post Post object.
+	 * @param obj $args Arguments object.
+	 */
+	public function render_hide_widget_metabox( $post, $args ){
+
+		$hide_republication_widget = get_post_meta( $post->ID, 'republication-tracker-tool-hide-widget', true );
+
+		$checked = '';
+
+		if( true == $hide_republication_widget ) {
+
+			$checked = 'checked';
+
+		}
+
+		echo '<label>';
+			echo '<input type="checkbox" name="republication-tracker-tool-hide-widget" id="republication-tracker-tool-hide-widget" '.$checked.'>';
+			echo __('Hide the Republication sharing widget on this post?', 'republication-tracker-tool');
+		echo '</label>';
+		
+
+	} 
 
 	public function add_custom_columns( $columns ) {
 		$columns['republication_tracker_tool'] = esc_html__( 'Total Views', 'republication-tracker-tool' );

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -39,7 +39,11 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 		global $post;
 
-		$hide_republication_widget_on_post = get_post_meta( $post->ID, 'republication-tracker-tool-hide-widget' )[0];
+		$hide_republication_widget_on_post = get_post_meta( $post->ID, 'republication-tracker-tool-hide-widget' );
+
+		if( $hide_republication_widget_on_post ){
+			$hide_republication_widget_on_post = $hide_republication_widget_on_post[0];
+		}
 
 		$hide_republication_widget_filter = apply_filters( 'hide_republication_widget', false );
 

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -38,6 +38,18 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 		}
 
 		global $post;
+
+		$hide_republication_widget_on_post = get_post_meta( $post->ID, 'republication-tracker-tool-hide-widget' )[0];
+
+		$hide_republication_widget_filter = apply_filters( 'hide_republication_widget', false );
+
+		// if `republication-tracker-tool-hide-widget` meta is set to true, don't show the shareable content widget
+		// OR if the `hide_republication_widget` filter is set to true, don't show the shareable content widget
+		if( true == $hide_republication_widget_on_post || true == $hide_republication_widget_filter ) {
+				
+			return;
+			
+		}
 		
 		// define our path to grab file content from
 		define( 'WPRTT_PATH', plugin_dir_path( __FILE__ ) );

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -39,17 +39,12 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 
 		global $post;
 
-		$hide_republication_widget_on_post = get_post_meta( $post->ID, 'republication-tracker-tool-hide-widget' );
-
-		if( $hide_republication_widget_on_post ){
-			$hide_republication_widget_on_post = $hide_republication_widget_on_post[0];
-		}
-
-		$hide_republication_widget_filter = apply_filters( 'hide_republication_widget', false );
+		// our post `republication-tracker-tool-hide-widget` meta is our default filter value
+		$hide_republication_widget_on_post = apply_filters( 'hide_republication_widget', get_post_meta( $post->ID, 'republication-tracker-tool-hide-widget', true ) );
 
 		// if `republication-tracker-tool-hide-widget` meta is set to true, don't show the shareable content widget
 		// OR if the `hide_republication_widget` filter is set to true, don't show the shareable content widget
-		if( true == $hide_republication_widget_on_post || true == $hide_republication_widget_filter ) {
+		if( true == $hide_republication_widget_on_post ) {
 				
 			return;
 			

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -40,7 +40,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 		global $post;
 
 		// our post `republication-tracker-tool-hide-widget` meta is our default filter value
-		$hide_republication_widget_on_post = apply_filters( 'hide_republication_widget', get_post_meta( $post->ID, 'republication-tracker-tool-hide-widget', true ) );
+		$hide_republication_widget_on_post = apply_filters( 'hide_republication_widget', get_post_meta( $post->ID, 'republication-tracker-tool-hide-widget', true ), $post );
 
 		// if `republication-tracker-tool-hide-widget` meta is set to true, don't show the shareable content widget
 		// OR if the `hide_republication_widget` filter is set to true, don't show the shareable content widget


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds a custom metabox to the post editor document sidebar to check/uncheck if the post should hide the Republication sharing widget
- Adds a new filter, `hide_republication_widget`, which allows developers to programmatically hide the sharing button on any specific post/page/taxonomy
   - It is currently set up to allow the filter to take priority. For example, if category A is hidden through the filter, but post 3 inside of category A wants to show the button, toggling the checkbox in the post editor won't make the button show.

![Screen Shot 2019-08-15 at 4 39 56 PM](https://user-images.githubusercontent.com/18353636/63125388-88e36f80-bf7b-11e9-9b30-141c7002aa7e.png)

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #51

## Testing/Questions

Features that this PR affects:

- Republication sharing button on posts

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [x] @benlk Do you think the priority is ok as it is, with the filter taking priority? Or should it function a different way?

Steps to test this PR:

1. Make sure the on/off checkbox in the post editor works
2. Make sure the filter works as expected
3. Make sure there are no weird priority edge cases between the filter and on/off checkbox.