### PR TITLE
Adds a max-width style attribute to the image pixel

### DIFF
--- a/includes/pixel.php
+++ b/includes/pixel.php
@@ -108,6 +108,6 @@ if ( isset( $_GET['post'] ) ) {
 }
 
 // grab our site icon and redirect to it once the script finishes
-$site_icon_url = get_site_icon_url();
+$site_icon_url = get_site_icon_url( 150 );
 wp_safe_redirect($site_icon_url, 303);
 exit;

--- a/includes/shareable-content.php
+++ b/includes/shareable-content.php
@@ -89,7 +89,7 @@ $attribution_statement = sprintf(
  */
 $pixel = sprintf(
 	// %1$s is the javascript source, %2$s is the post ID, %3$s is the plugins URL
-	'<img id="republication-tracker-tool-source" src="%1$s/?republication-pixel=true&post=%2$s&ga=%3$s">',
+	'<img id="republication-tracker-tool-source" src="%1$s/?republication-pixel=true&post=%2$s&ga=%3$s" style="max-width:200px;">',
 	esc_attr( get_site_url( ) ),
 	esc_attr( $post->ID ),
 	esc_attr( $analytics_id )


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Adds a `max-width:200px;` style attribute to the image pixel as a fallback. However, this doesn't work with Gutenberg since the image is made into an image block when it is pasted and the style attribute is stripped. Sites may need to add custom css when pasting it in.

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #55

## Testing/Questions

Features that this PR affects:

- Pixel image element

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] @benlk you don't know of any other way to force a style attribute into the image block when it's pasted, do you?