### PR TITLE
Allow multiple instances of Republication widget to coexist

### DIFF
--- a/assets/widget.js
+++ b/assets/widget.js
@@ -21,7 +21,7 @@ function modal_actions(){
 	// Responsive modal
 	var $modal = $('#republication-tracker-tool-modal');
 	var $modal_content = $('#republication-tracker-tool-modal-content');
-	var $btn = $('#cc-btn');
+	var $btn = $('.republication-tracker-tool-button');
 	var $close = $('.republication-tracker-tool-close');
 
 	$btn.click(function(){

--- a/includes/class-widget.php
+++ b/includes/class-widget.php
@@ -13,6 +13,8 @@
  */
 class Republication_Tracker_Tool_Widget extends WP_Widget {
 
+	public $has_instance = false;
+
 	/**
 	 * Sets up the widgets name etc
 	 */
@@ -51,7 +53,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 		}
 		
 		// define our path to grab file content from
-		define( 'WPRTT_PATH', plugin_dir_path( __FILE__ ) );
+		$republication_plugin_path = plugin_dir_path( __FILE__ );
 
 		wp_enqueue_script( 'republication-tracker-tool-js', plugins_url( 'assets/widget.js', dirname( __FILE__ ) ), array( 'jquery' ), Republication_Tracker_Tool::VERSION, false );
 		wp_enqueue_style( 'republication-tracker-tool-css', plugins_url( 'assets/widget.css', dirname( __FILE__ ) ), array(), Republication_Tracker_Tool::VERSION );
@@ -63,13 +65,6 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 		if ( ! empty( $instance['title'] ) ) {
 			echo wp_kses_post( $args['before_title'] . esc_html( apply_filters( 'widget_title', $instance['title'] ) ) . $args['after_title'] );
 		}
-
-		printf(
-			'<div id="republication-tracker-tool-modal" style="display:none;" data-postid="%1$s" data-pluginsdir="%2$s">%3$s</div>',
-			esc_attr( $post->ID ),
-			esc_attr( plugins_url() ),
-			esc_html( include_once( WPRTT_PATH . 'shareable-content.php' ) )
-		);
 
 		echo '<div class="license">';
 			echo sprintf(
@@ -89,6 +84,21 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 		);
 
 		echo wp_kses_post( $args['after_widget'] );
+
+		// if has_instance is false, we can continue with displaying the modal
+		if( isset( $this->has_instance ) && false === $this->has_instance ){
+
+			// update has_instance so the next time the widget is created on the same page, it does not create a second modal
+			$this->has_instance = true;
+
+			printf(
+				'<div id="republication-tracker-tool-modal" style="display:none;" data-postid="%1$s" data-pluginsdir="%2$s">%3$s</div>',
+				esc_attr( $post->ID ),
+				esc_attr( plugins_url() ),
+				esc_html( include_once( $republication_plugin_path . 'shareable-content.php' ) )
+			);
+
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- Swaps `$btn` to look for clicks on `.republication-tracker-tool-button` instead of `#cc-btn`
- Changes `WRTT_PATH` constant the `$republication_plugin_path` variable so that we don't get "const. cannot be redefined" errors
- Sets `$has_instance` global class variable that will update to `true` if an instance of the widget already exists, and uses this to make sure the modal is only output once on the page

## Why

<!-- Why does this PR propose these changes? Take as much space as you need to explain. -->
<!-- If there are GitHub issues that this pull request addresses, please list them here. -->
For #66 

## Testing/Questions

Features that this PR affects:

- Republication frontend widget button and modal

<!-- If there are no questions, please remove the questions section. -->
Questions that need to be answered before merging:

- [ ] Is this PR targeting the correct branch in this repository?

Steps to test this PR:

1. Add multiple instances of the Republication widget via widget areas
2. Add the widget to the post template using this method: https://github.com/INN/republication-tracker-tool/issues/66#issuecomment-566762165
3. Verify all instances of the widget on the page function as expected and all open the expected modal without issue.