### PR TITLE
modal show by URL hash

### DIFF
--- a/assets/widget.js
+++ b/assets/widget.js
@@ -20,29 +20,51 @@ function modal_actions(){
 
 	// Responsive modal
 	var $modal = $('#republication-tracker-tool-modal');
-	var $modal_content = $('#republication-tracker-tool-modal-content');
-	var $btn = $('.republication-tracker-tool-button');
+	var $btn = $('#cc-btn');
 	var $close = $('.republication-tracker-tool-close');
 
+	// url hash of #show-republish: open the modal
+	if ( '#show-republish' === window.location.hash ) {
+		show_modal( $modal );
+	}
+
+	// click the republish button: open the modal
 	$btn.click(function(){
-		//$modal.html( html );
-		$modal.show();
-		$modal_content.show();
-		$('body').addClass('modal-open-disallow-scrolling');
-		$('#republication-tracker-tool-modal-content').unbind().click(function(e) {
-			e.stopPropagation();
-		});
+		show_modal( $modal );
 	});
 
+	// click on the modal: close the modal
 	$modal.click(function(){
-		$('body').removeClass('modal-open-disallow-scrolling');
-		$modal.hide();
+		close_modal( $modal );
 	});
 
+	// close button click: close the modal
 	$close.click(function(){
-		$('body').removeClass('modal-open-disallow-scrolling');
-		$modal.hide();
+		close_modal( $modal );
 	});
+
+	// escape key press: close the modal
+	$(document).keyup(function(e) {
+		if (27 === e.keyCode) {
+			close_modal( $modal );
+		}
+	});
+}
+
+function show_modal( $modal ) {
+	var $modal_content = $('#republication-tracker-tool-modal-content');
+	//$modal.html( html );
+	$modal.show();
+	$modal_content.show();
+	$('body').addClass('modal-open-disallow-scrolling');
+	$('#republication-tracker-tool-modal-content').unbind().click(function(e) {
+		e.stopPropagation();
+	});
+}
+
+function close_modal( $modal ) {
+	$('body').removeClass('modal-open-disallow-scrolling');
+	$modal.hide();
 }
 
 jQuery(document).ready(function(){

--- a/assets/widget.js
+++ b/assets/widget.js
@@ -52,6 +52,7 @@ function modal_actions(){
 }
 
 function show_modal( $modal ) {
+	var $ = jQuery;
 	var $modal_content = $('#republication-tracker-tool-modal-content');
 	//$modal.html( html );
 	$modal.show();
@@ -63,6 +64,7 @@ function show_modal( $modal ) {
 }
 
 function close_modal( $modal ) {
+	var $ = jQuery;
 	$('body').removeClass('modal-open-disallow-scrolling');
 	$modal.hide();
 }

--- a/assets/widget.js
+++ b/assets/widget.js
@@ -20,7 +20,7 @@ function modal_actions(){
 
 	// Responsive modal
 	var $modal = $('#republication-tracker-tool-modal');
-	var $btn = $('#cc-btn');
+	var $btn = $('.republication-tracker-tool-button');
 	var $close = $('.republication-tracker-tool-close');
 
 	// url hash of #show-republish: open the modal


### PR DESCRIPTION
## Changes

This pull request makes the following changes:

- This allows the modal to show if the url contains `#show-republish`.
- It also adds a close handler if the user presses the Escape key.
- To do both these things, there's a `show_modal( $modal )` function and a `close_modal( $modal )` function

## Why

If approved, this would address #76. The Escape button part is because many keyboard users expect the escape key to close things like modals. This can be an [accessibility best practice](https://simplyaccessible.com/article/closing-modals/).

## Testing/Questions

Features that this PR affects:

- opening and closing of the modal and display of the modal's content

Steps to test this PR:

1. Open a modal with the click on the widget button
2. Open a modal with the URL hash
3. Close the modal with a click on the close button
4. Close the modal with a click outside the modal
5. Close the modal by pressing the escape key on the keyboard

## Additional information

INN Member/Labs Client requesting: MinnPost

- [x] Contributor has read INN's [GitHub code of conduct](https://github.com/INN/.github/blob/master/CODE_OF_CONDUCT.md)
- [x] Contributor would like to be mentioned in the release notes as: @jonathanstegall is fine
- [x] Contributor agrees to the license terms of this repository.
